### PR TITLE
Issue #5: centos7-rpm-builder and rockylinux8-rpm-builder support existing user and group

### DIFF
--- a/.github/workflows/cd-centos7-devtoolset8-builder.yaml
+++ b/.github/workflows/cd-centos7-devtoolset8-builder.yaml
@@ -8,7 +8,7 @@ name: CD for centos7-devtoolset8-builder
 on:
   push:
     branches: ['main']
-    paths: ['centos7-devtoolset8-builder/**']
+    paths: ['!**/*.md', 'centos7-devtoolset8-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./centos7-devtoolset8-builder
           push: true

--- a/.github/workflows/cd-centos7-rpm-builder.yaml
+++ b/.github/workflows/cd-centos7-rpm-builder.yaml
@@ -8,7 +8,7 @@ name: CD for centos7-rpm-builder
 on:
   push:
     branches: ['main']
-    paths: ['centos7-rpm-builder/**']
+    paths: ['!**/*.md', 'centos7-rpm-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./centos7-rpm-builder
           push: true

--- a/.github/workflows/cd-rockylinux8-rpm-builder.yaml
+++ b/.github/workflows/cd-rockylinux8-rpm-builder.yaml
@@ -8,7 +8,7 @@ name: CD for rockylinux8-rpm-builder
 on:
   push:
     branches: ['main']
-    paths: ['rockylinux8-rpm-builder/**']
+    paths: ['!**/*.md', 'rockylinux8-rpm-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./rockylinux8-rpm-builder
           push: true

--- a/.github/workflows/ci-centos7-devtoolset8-builder.yaml
+++ b/.github/workflows/ci-centos7-devtoolset8-builder.yaml
@@ -8,7 +8,7 @@ name: CI for centos7-devtoolset8-builder
 on:
   pull_request:
     branches: ['main']
-    paths: ['centos7-devtoolset8-builder/**']
+    paths: ['!**/*.md', 'centos7-devtoolset8-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./centos7-devtoolset8-builder
           push: false

--- a/.github/workflows/ci-centos7-rpm-builder.yaml
+++ b/.github/workflows/ci-centos7-rpm-builder.yaml
@@ -8,7 +8,7 @@ name: CI for centos7-rpm-builder
 on:
   pull_request:
     branches: ['main']
-    paths: ['centos7-rpm-builder/**']
+    paths: ['!**/*.md', 'centos7-rpm-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./centos7-rpm-builder
           push: false

--- a/.github/workflows/ci-rockylinux8-rpm-builder.yaml
+++ b/.github/workflows/ci-rockylinux8-rpm-builder.yaml
@@ -8,7 +8,7 @@ name: CI for rockylinux8-rpm-builder
 on:
   pull_request:
     branches: ['main']
-    paths: ['rockylinux8-rpm-builder/**']
+    paths: ['!**/*.md', 'rockylinux8-rpm-builder/**']
 
 env:
   REGISTRY: ghcr.io
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,12 +34,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./rockylinux8-rpm-builder
           push: false

--- a/centos7-rpm-builder/README.md
+++ b/centos7-rpm-builder/README.md
@@ -19,7 +19,7 @@ ENV _USER_ID ${_USER_ID:-1001}
 ENV _GROUP_ID ${_GROUP_ID:-1002}
 
 # Run script to create users and declare new user as default
-RUN setup_users.sh
+RUN setup_rpm_users
 USER $_USER_ID:$_GROUP_ID
 
 # Install any needed packages here

--- a/centos7-rpm-builder/setup_rpm_users
+++ b/centos7-rpm-builder/setup_rpm_users
@@ -41,12 +41,35 @@ function do_run() {
     detect_env_var "_USER_ID" true
     detect_env_var "_GROUP_ID" true
 
-    echo "Adding builder user/group ($_USER_ID:$_GROUP_ID)"
-    groupadd -g "$_GROUP_ID" builder
-    useradd -u "$_USER_ID" -g builder builder
-    echo "builder        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
-    echo "Id for builder:"
-    id builder
+    echo "Adding builder user/group ($_USER_ID:$_GROUP_ID) ..."
+    # Detecting existing user and group
+    set +e
+    existing_group_name="$(getent group "$_GROUP_ID" | cut -d: -f1)"
+    existing_user_name="$(getent passwd "$_USER_ID" | cut -d: -f1)"
+    set -e
+    # Group creation
+    if [ "$existing_group_name" != "" ]; then
+        echo "Skipping creating builder group as group with desired ID $_GROUP_ID already exists: $existing_group_name"
+    else
+        echo "Creating builder group ..."
+        groupadd -g "$_GROUP_ID" builder
+    fi
+    final_group_name="$(getent group "$_GROUP_ID" | cut -d: -f1)"
+    # User creation
+    if [ "$existing_user_name" != "" ]; then
+        echo "Skipping creating builder user as user with desired ID $_USER_ID already exists: $existing_user_name"
+        echo "Attempting to add existing user to group $final_group_name ($_GROUP_ID) ..."
+        usermod -a -G "$final_group_name" "$existing_user_name"
+    else
+        echo "Creating builder user ..."
+        useradd -u "$_USER_ID" -g "$_GROUP_ID" builder
+    fi
+    # Add to sudoers
+    final_user_name="$(getent passwd "$_USER_ID" | cut -d: -f1)"
+    echo "$final_user_name        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+
+    echo "Id for container user:"
+    id "$_USER_ID"
 }
 
 function main() {

--- a/rockylinux8-rpm-builder/README.md
+++ b/rockylinux8-rpm-builder/README.md
@@ -19,7 +19,7 @@ ENV _USER_ID ${_USER_ID:-1001}
 ENV _GROUP_ID ${_GROUP_ID:-1002}
 
 # Run script to create users and declare new user as default
-RUN setup_users.sh
+RUN setup_rpm_users
 USER $_USER_ID:$_GROUP_ID
 
 # Install any needed packages here

--- a/rockylinux8-rpm-builder/setup_rpm_users
+++ b/rockylinux8-rpm-builder/setup_rpm_users
@@ -41,12 +41,35 @@ function do_run() {
     detect_env_var "_USER_ID" true
     detect_env_var "_GROUP_ID" true
 
-    echo "Adding builder user/group ($_USER_ID:$_GROUP_ID)"
-    groupadd -g "$_GROUP_ID" builder
-    useradd -u "$_USER_ID" -g builder builder
-    echo "builder        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
-    echo "Id for builder:"
-    id builder
+    echo "Adding builder user/group ($_USER_ID:$_GROUP_ID) ..."
+    # Detecting existing user and group
+    set +e
+    existing_group_name="$(getent group "$_GROUP_ID" | cut -d: -f1)"
+    existing_user_name="$(getent passwd "$_USER_ID" | cut -d: -f1)"
+    set -e
+    # Group creation
+    if [ "$existing_group_name" != "" ]; then
+        echo "Skipping creating builder group as group with desired ID $_GROUP_ID already exists: $existing_group_name"
+    else
+        echo "Creating builder group ..."
+        groupadd -g "$_GROUP_ID" builder
+    fi
+    final_group_name="$(getent group "$_GROUP_ID" | cut -d: -f1)"
+    # User creation
+    if [ "$existing_user_name" != "" ]; then
+        echo "Skipping creating builder user as user with desired ID $_USER_ID already exists: $existing_user_name"
+        echo "Attempting to add existing user to group $final_group_name ($_GROUP_ID) ..."
+        usermod -a -G "$final_group_name" "$existing_user_name"
+    else
+        echo "Creating builder user ..."
+        useradd -u "$_USER_ID" -g "$_GROUP_ID" builder
+    fi
+    # Add to sudoers
+    final_user_name="$(getent passwd "$_USER_ID" | cut -d: -f1)"
+    echo "$final_user_name        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+
+    echo "Id for container user:"
+    id "$_USER_ID"
 }
 
 function main() {


### PR DESCRIPTION
## Related Issues

1. #5

## Changes

1. Made `setup_rpm_users` script support existing user ID and group ID to prevent erroring if existing IDs given, via `centos7-rpm-builder/setup_rpm_users` and `rockylinux8-rpm-builder/setup_rpm_users`.
2. Set all Github Actions to ignore changes to Markdown files, via `.github/workflows/`.
3. Updated all Github Actions versions, via `.github/workflows/`.
4. Corrected typo in instructions, via `centos7-rpm-builder/README.md` and `rockylinux8-rpm-builder/README.md`.